### PR TITLE
Add tests for going direct to unit page

### DIFF
--- a/tests/selenium/unit_page_test.py
+++ b/tests/selenium/unit_page_test.py
@@ -52,6 +52,13 @@ class UnitPageTest(unittest.TestCase):
         for unit_variable in list(flattened_vars.values()):
             self.assertTrue(unit_variable in self.driver.page_source)
 
+    def test_go_direct_to_ent_page(self):
+        self.driver.get(f'{SEARCH_URL}/periods/{PERIOD}/types/ENT/units/{ENTREF}')
+        self.assert_title(UNIT_NAME_ID, enterprise.get('vars').get('name'))
+        self.assertEqual(self.driver.find_element_by_id(UNIT_BADGE_ID).text, 'ENTERPRISE')
+        self.assertEqual(self.driver.find_element_by_id(UNIT_ID_ID).text, f'ERN {ENTREF}')
+        self.assert_dict_values_present_on_page(enterprise.get('vars'))
+
     def test_ent_page_contents(self):
         self.search_by_unit_id_type_period(ENTREF, 'ENT', '201810')
         self.assertEqual(self.driver.current_url, f'{SEARCH_URL}/periods/{PERIOD}/types/ENT/units/{ENTREF}')
@@ -59,6 +66,13 @@ class UnitPageTest(unittest.TestCase):
         self.assertEqual(self.driver.find_element_by_id(UNIT_BADGE_ID).text, 'ENTERPRISE')
         self.assertEqual(self.driver.find_element_by_id(UNIT_ID_ID).text, f'ERN {ENTREF}')
         self.assert_dict_values_present_on_page(enterprise.get('vars'))
+
+    def test_go_direct_to_leu_page(self):
+        self.driver.get(f'{SEARCH_URL}/periods/{PERIOD}/types/LEU/units/{UBRN}')
+        self.assert_title(UNIT_NAME_ID, legal_unit.get('vars').get('name'))
+        self.assertEqual(self.driver.find_element_by_id(UNIT_BADGE_ID).text, 'LEGAL UNIT')
+        self.assertEqual(self.driver.find_element_by_id(UNIT_ID_ID).text, f'UBRN {UBRN}')
+        self.assert_dict_values_present_on_page(legal_unit.get('vars'))
 
     def test_leu_page_contents(self):
         self.search_by_unit_id_type_period(UBRN, 'LEU', '201810')
@@ -68,6 +82,13 @@ class UnitPageTest(unittest.TestCase):
         self.assertEqual(self.driver.find_element_by_id(UNIT_ID_ID).text, f'UBRN {UBRN}')
         self.assert_dict_values_present_on_page(legal_unit.get('vars'))
 
+    def test_go_direct_to_lou_page(self):
+        self.driver.get(f'{SEARCH_URL}/periods/{PERIOD}/types/LOU/units/{LURN}')
+        self.assert_title(UNIT_NAME_ID, local_unit.get('vars').get('name'))
+        self.assertEqual(self.driver.find_element_by_id(UNIT_BADGE_ID).text, 'LOCAL UNIT')
+        self.assertEqual(self.driver.find_element_by_id(UNIT_ID_ID).text, f'LURN {LURN}')
+        self.assert_dict_values_present_on_page(local_unit.get('vars'))
+
     def test_lou_page_contents(self):
         self.search_by_unit_id_type_period(LURN, 'LOU', '201810')
         self.assertEqual(self.driver.current_url, f'{SEARCH_URL}/periods/{PERIOD}/types/LOU/units/{LURN}')
@@ -75,6 +96,13 @@ class UnitPageTest(unittest.TestCase):
         self.assertEqual(self.driver.find_element_by_id(UNIT_BADGE_ID).text, 'LOCAL UNIT')
         self.assertEqual(self.driver.find_element_by_id(UNIT_ID_ID).text, f'LURN {LURN}')
         self.assert_dict_values_present_on_page(local_unit.get('vars'))
+
+    def test_go_direct_to_reu_page(self):
+        self.driver.get(f'{SEARCH_URL}/periods/{PERIOD}/types/REU/units/{RURN}')
+        self.assert_title(UNIT_NAME_ID, reporting_unit.get('vars').get('name'))
+        self.assertEqual(self.driver.find_element_by_id(UNIT_BADGE_ID).text, 'REPORTING UNIT')
+        self.assertEqual(self.driver.find_element_by_id(UNIT_ID_ID).text, f'RURN {RURN}')
+        self.assert_dict_values_present_on_page(reporting_unit.get('vars'))
 
     def test_reu_page_contents(self):
         self.search_by_unit_id_type_period(RURN, 'REU', '201810')
@@ -84,6 +112,13 @@ class UnitPageTest(unittest.TestCase):
         self.assertEqual(self.driver.find_element_by_id(UNIT_ID_ID).text, f'RURN {RURN}')
         self.assert_dict_values_present_on_page(reporting_unit.get('vars'))
 
+    def test_go_direct_to_ch_page(self):
+        self.driver.get(f'{SEARCH_URL}/periods/{PERIOD}/types/CH/units/{CRN}')
+        self.assert_title(UNIT_NAME_ID, company_house.get('vars').get('businessName'))
+        self.assertEqual(self.driver.find_element_by_id(UNIT_BADGE_ID).text, 'COMPANY HOUSE')
+        self.assertEqual(self.driver.find_element_by_id(UNIT_ID_ID).text, f'CRN {CRN}')
+        self.assert_dict_values_present_on_page(company_house.get('vars'))
+
     def test_ch_page_contents(self):
         self.search_by_unit_id_type_period(CRN, 'CH', '201810')
         self.assertEqual(self.driver.current_url, f'{SEARCH_URL}/periods/{PERIOD}/types/CH/units/{CRN}')
@@ -92,6 +127,13 @@ class UnitPageTest(unittest.TestCase):
         self.assertEqual(self.driver.find_element_by_id(UNIT_ID_ID).text, f'CRN {CRN}')
         self.assert_dict_values_present_on_page(company_house.get('vars'))
 
+    def test_go_direct_to_vat_page(self):
+        self.driver.get(f'{SEARCH_URL}/periods/{PERIOD}/types/VAT/units/{VATREF}')
+        self.assert_title(UNIT_NAME_ID, value_added_tax.get('vars').get('businessName'))
+        self.assertEqual(self.driver.find_element_by_id(UNIT_BADGE_ID).text, 'VALUE ADDED TAX')
+        self.assertEqual(self.driver.find_element_by_id(UNIT_ID_ID).text, f'VATREF {VATREF}')
+        self.assert_dict_values_present_on_page(value_added_tax.get('vars'))
+
     def test_vat_page_contents(self):
         self.search_by_unit_id_type_period(VATREF, 'VAT', '201810')
         self.assertEqual(self.driver.current_url, f'{SEARCH_URL}/periods/{PERIOD}/types/VAT/units/{VATREF}')
@@ -99,6 +141,13 @@ class UnitPageTest(unittest.TestCase):
         self.assertEqual(self.driver.find_element_by_id(UNIT_BADGE_ID).text, 'VALUE ADDED TAX')
         self.assertEqual(self.driver.find_element_by_id(UNIT_ID_ID).text, f'VATREF {VATREF}')
         self.assert_dict_values_present_on_page(value_added_tax.get('vars'))
+
+    def test_go_direct_to_paye_page(self):
+        self.driver.get(f'{SEARCH_URL}/periods/{PERIOD}/types/PAYE/units/{PAYEREF}')
+        self.assert_title(UNIT_NAME_ID, pay_as_you_earn.get('vars').get('businessName'))
+        self.assertEqual(self.driver.find_element_by_id(UNIT_BADGE_ID).text, 'PAY AS YOU EARN')
+        self.assertEqual(self.driver.find_element_by_id(UNIT_ID_ID).text, f'PAYEREF {PAYEREF}')
+        self.assert_dict_values_present_on_page(pay_as_you_earn.get('vars'))
 
     def test_paye_page_contents(self):
         self.search_by_unit_id_type_period(PAYEREF, 'PAYE', '201810')


### PR DESCRIPTION
- To ensure unit page routes can check the session for json and do a search if no json is present